### PR TITLE
Dockerfile : réutilisation argument TOMCAT_USER

### DIFF
--- a/docker/tomcat/Dockerfile
+++ b/docker/tomcat/Dockerfile
@@ -1,5 +1,6 @@
 ARG ALPINE_VERSION=3.19
 ARG TOMCAT_VERSION=9.0.87-jre11
+ARG TOMCAT_USER=tomcat
 
 # Stage builder
 FROM alpine:${ALPINE_VERSION} as builder
@@ -34,7 +35,7 @@ FROM tomcat:${TOMCAT_VERSION} as runner
 
 USER root
 # non root user
-ARG TOMCAT_USER=tomcat
+ARG TOMCAT_USER
 RUN apt-get -qy update  ; apt-get install -qy unzip
 
 RUN groupadd -r ${TOMCAT_USER} -g 1000 && \
@@ -80,6 +81,7 @@ ENV JAVA_OPTS_CUSTOM="-Xmx512m"
 
 # Stage mock
 FROM runner as mock
+ARG TOMCAT_USER
 COPY --from=builder --chown=${TOMCAT_USER}:${TOMCAT_USER} /data/TOMCAT/IdP.war /usr/local/tomcat/webapps/
 COPY --from=builder --chown=${TOMCAT_USER}:${TOMCAT_USER} /data/TOMCAT/SP.war /usr/local/tomcat/webapps/
 COPY --from=builder --chown=${TOMCAT_USER}:${TOMCAT_USER} /data/TOMCAT/SpecificConnector.war /usr/local/tomcat/webapps/


### PR DESCRIPTION
Sans ça j'ai l'erreur suivante à la commande `make build-tomcat`, qui me semble indiquer que la variable `TOMCAT_USER` n'est plus connue dans ce contexte :

```
Step 36/42 : COPY --from=builder --chown=${TOMCAT_USER}:${TOMCAT_USER} /data/TOMCAT/IdP.war /usr/local/tomcat/webapps/
unable to convert uid/gid chown string to host mapping: can't find uid for user : no such user: 
make: *** [Makefile:31: build-eidas-node-tomcat] Error 1
```

